### PR TITLE
Added some relations

### DIFF
--- a/db/ringapp/property/PROP_000002/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000002/metaproperties.yaml
@@ -20,7 +20,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 168
-  example: null
+  example: RING_000002
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000002

--- a/db/ringapp/property/PROP_000003/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000003/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 547
+  crosstable_pk: 544
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000004/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000004/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 548
+  crosstable_pk: 545
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000005/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000005/metaproperties.yaml
@@ -20,7 +20,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 138
-  example: null
+  example: RING_000016
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000005

--- a/db/ringapp/property/PROP_000006/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000006/metaproperties.yaml
@@ -19,21 +19,21 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 618
+  crosstable_pk: 633
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000006
-  relation: 12
+  relation: 166
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 525
+  crosstable_pk: 598
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000006
-  relation: 13
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000007/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000007/metaproperties.yaml
@@ -6,16 +6,16 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000007
-  relation: 12
+  relation: 166
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 526
+  crosstable_pk: 599
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000007
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000008/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000008/metaproperties.yaml
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 1
-  example: null
+  example: RING_000049
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000008
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000009/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000009/metaproperties.yaml
@@ -24,16 +24,16 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000009
-  relation: 12
+  relation: 166
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 527
+  crosstable_pk: 600
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000009
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000010/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000010/metaproperties.yaml
@@ -29,11 +29,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 232
-  example: null
+  example: RING_000049
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000010
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000011/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000011/metaproperties.yaml
@@ -19,21 +19,21 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 620
+  crosstable_pk: 635
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000011
-  relation: 12
+  relation: 166
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 528
+  crosstable_pk: 601
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000011
-  relation: 3
+  relation: 109
 METAPROP_000008:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000012/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000012/metaproperties.yaml
@@ -19,7 +19,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 549
+  crosstable_pk: 546
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000013/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000013/metaproperties.yaml
@@ -20,7 +20,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 550
+  crosstable_pk: 547
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000014/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000014/metaproperties.yaml
@@ -19,7 +19,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 551
+  crosstable_pk: 548
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000015/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000015/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 552
+  crosstable_pk: 580
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
@@ -10,9 +10,9 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 531
+  crosstable_pk: 604
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000015
-  relation: 3
+  relation: 109

--- a/db/ringapp/property/PROP_000016/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000016/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 553
+  crosstable_pk: 549
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000017/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000017/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 554
+  crosstable_pk: 550
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000018/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000018/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 555
+  crosstable_pk: 551
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000019/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000019/metaproperties.yaml
@@ -19,7 +19,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 556
+  crosstable_pk: 552
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000020/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000020/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 557
+  crosstable_pk: 553
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000021/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000021/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 621
+  crosstable_pk: 636
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000021
-  relation: 12
+  relation: 166

--- a/db/ringapp/property/PROP_000023/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000023/metaproperties.yaml
@@ -10,7 +10,7 @@ METAPROP_000001:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 558
+  crosstable_pk: 531
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000024/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000024/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 559
+  crosstable_pk: 532
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000025/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000025/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 560
+  crosstable_pk: 533
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000027/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000027/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 616
+  crosstable_pk: 534
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000027
-  relation: 7
+  relation: 2

--- a/db/ringapp/property/PROP_000028/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000028/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 561
+  crosstable_pk: 554
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000029/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000029/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 562
+  crosstable_pk: 535
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000030/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000030/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 563
+  crosstable_pk: 536
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000031/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000031/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 564
+  crosstable_pk: 537
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000037/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000037/metaproperties.yaml
@@ -33,7 +33,7 @@ METAPROP_000004:
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000037
-  relation: 16
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000038/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000038/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 532
+  crosstable_pk: 605
   example: null
-  has_metaproperty: null
+  has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000038
-  relation: null
+  relation: 109

--- a/db/ringapp/property/PROP_000045/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000045/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 565
+  crosstable_pk: 555
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000047/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000047/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 566
+  crosstable_pk: 538
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000048/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000048/metaproperties.yaml
@@ -1,12 +1,21 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 567
+  crosstable_pk: 527
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000048
   relation: 1
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 595
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000048
+  relation: 107
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000049/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000049/metaproperties.yaml
@@ -1,9 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 568
+  crosstable_pk: 528
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000049
   relation: 1
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 596
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000049
+  relation: 107

--- a/db/ringapp/property/PROP_000050/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000050/metaproperties.yaml
@@ -21,7 +21,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 569
+  crosstable_pk: 539
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000052/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000052/metaproperties.yaml
@@ -22,7 +22,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 55
-  example: null
+  example: RING_000070
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000052

--- a/db/ringapp/property/PROP_000053/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000053/metaproperties.yaml
@@ -21,7 +21,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 570
+  crosstable_pk: 541
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000054/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000054/metaproperties.yaml
@@ -20,7 +20,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 242
-  example: null
+  example: RING_000002
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000054

--- a/db/ringapp/property/PROP_000055/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000055/metaproperties.yaml
@@ -2,11 +2,11 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 387
-  example: null
+  example: RING_000004
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000055
-  relation: 4
+  relation: 32
 METAPROP_000004:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000056/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000056/metaproperties.yaml
@@ -6,7 +6,7 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000056
-  relation: 8
+  relation: 31
 METAPROP_000004:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000057/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000057/metaproperties.yaml
@@ -2,11 +2,11 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 391
-  example: null
+  example: RING_000004
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000057
-  relation: 4
+  relation: 32
 METAPROP_000004:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000058/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000058/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 389
-  example: null
+  example: RING_000003
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000058

--- a/db/ringapp/property/PROP_000059/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000059/metaproperties.yaml
@@ -2,11 +2,11 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 386
-  example: null
+  example: RING_000003
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000059
-  relation: 4
+  relation: 31
 METAPROP_000004:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000060/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000060/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 388
-  example: null
+  example: RING_000003
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000060

--- a/db/ringapp/property/PROP_000061/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000061/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 390
-  example: null
+  example: RING_000003
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000061

--- a/db/ringapp/property/PROP_000062/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000062/metaproperties.yaml
@@ -6,7 +6,7 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000062
-  relation: 7
+  relation: 2
 METAPROP_000004:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000063/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000063/metaproperties.yaml
@@ -20,7 +20,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 38
-  example: null
+  example: RING_000002
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000063

--- a/db/ringapp/property/PROP_000064/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000064/metaproperties.yaml
@@ -19,12 +19,12 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 609
+  crosstable_pk: 628
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000064
-  relation: 5
+  relation: 164
 METAPROP_000004:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000065/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000065/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 361
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000065
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 347
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000065
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000066/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000066/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 366
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000066

--- a/db/ringapp/property/PROP_000068/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000068/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 354
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000068
@@ -10,12 +10,12 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 533
+  crosstable_pk: 606
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000068
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000069/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000069/metaproperties.yaml
@@ -2,11 +2,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 340
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000069
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000070/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000070/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 571
+  crosstable_pk: 581
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
@@ -10,9 +10,9 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 534
+  crosstable_pk: 607
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000070
-  relation: 3
+  relation: 109

--- a/db/ringapp/property/PROP_000071/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000071/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 572
+  crosstable_pk: 582
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
@@ -10,9 +10,9 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 535
+  crosstable_pk: 608
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000071
-  relation: 3
+  relation: 109

--- a/db/ringapp/property/PROP_000072/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000072/metaproperties.yaml
@@ -1,21 +1,21 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 619
+  crosstable_pk: 634
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000072
-  relation: 12
+  relation: 166
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 536
+  crosstable_pk: 609
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000072
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000073/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000073/metaproperties.yaml
@@ -1,12 +1,12 @@
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 537
+  crosstable_pk: 610
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000073
-  relation: 3
+  relation: 109
 METAPROP_000012:
   citation:
   - 329

--- a/db/ringapp/property/PROP_000074/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000074/metaproperties.yaml
@@ -19,7 +19,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 573
+  crosstable_pk: 556
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000076/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000076/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 367
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000076

--- a/db/ringapp/property/PROP_000077/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000077/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 574
+  crosstable_pk: 557
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000078/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000078/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 575
+  crosstable_pk: 558
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000079/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000079/metaproperties.yaml
@@ -1,12 +1,12 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 625
+  crosstable_pk: 638
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000079
-  relation: 14
+  relation: 167
 METAPROP_000004:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000080/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000080/metaproperties.yaml
@@ -19,7 +19,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 576
+  crosstable_pk: 559
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000081/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000081/metaproperties.yaml
@@ -7,6 +7,15 @@ METAPROP_000003:
   metaproperty: METAPROP_000003
   property: PROP_000081
   relation: 1
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 589
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000081
+  relation: 105
 METAPROP_000006:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000082/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000082/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 577
+  crosstable_pk: 560
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000083/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000083/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 578
+  crosstable_pk: 561
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000088/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000088/metaproperties.yaml
@@ -6,4 +6,4 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000088
-  relation: 5
+  relation: 164

--- a/db/ringapp/property/PROP_000091/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000091/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 579
+  crosstable_pk: 562
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000092/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000092/metaproperties.yaml
@@ -21,7 +21,7 @@ METAPROP_000002:
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 580
+  crosstable_pk: 563
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000093/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000093/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 581
+  crosstable_pk: 583
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
@@ -10,9 +10,9 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 538
+  crosstable_pk: 611
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000093
-  relation: 3
+  relation: 109

--- a/db/ringapp/property/PROP_000095/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000095/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 582
+  crosstable_pk: 564
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000097/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000097/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 622
+  crosstable_pk: 637
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000097
-  relation: 12
+  relation: 166

--- a/db/ringapp/property/PROP_000098/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000098/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 583
+  crosstable_pk: 565
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
@@ -10,9 +10,9 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 635
+  crosstable_pk: 592
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000098
-  relation: 15
+  relation: 106

--- a/db/ringapp/property/PROP_000100/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000100/metaproperties.yaml
@@ -1,9 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 584
+  crosstable_pk: 525
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000100
   relation: 1
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 590
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000100
+  relation: 105

--- a/db/ringapp/property/PROP_000101/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000101/metaproperties.yaml
@@ -1,9 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 585
+  crosstable_pk: 526
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000101
   relation: 1
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 591
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000101
+  relation: 105

--- a/db/ringapp/property/PROP_000102/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000102/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 586
+  crosstable_pk: 566
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000103/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000103/metaproperties.yaml
@@ -1,9 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 587
+  crosstable_pk: 567
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000103
   relation: 1
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 593
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000103
+  relation: 106

--- a/db/ringapp/property/PROP_000104/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000104/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 588
+  crosstable_pk: 579
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000105/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000105/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 539
+  crosstable_pk: 612
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000105
-  relation: 15
+  relation: 109

--- a/db/ringapp/property/PROP_000106/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000106/metaproperties.yaml
@@ -1,18 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 626
+  crosstable_pk: 639
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000106
-  relation: 14
+  relation: 167
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 623
+  crosstable_pk: 616
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000106
-  relation: 13
+  relation: 150

--- a/db/ringapp/property/PROP_000107/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000107/metaproperties.yaml
@@ -1,18 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 627
+  crosstable_pk: 640
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000107
-  relation: 14
+  relation: 167
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 637
+  crosstable_pk: 622
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000107
-  relation: 15
+  relation: 153

--- a/db/ringapp/property/PROP_000108/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000108/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 589
+  crosstable_pk: 568
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000109/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000109/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 639
+  crosstable_pk: 617
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000109
-  relation: 15
+  relation: 150

--- a/db/ringapp/property/PROP_000110/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000110/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 640
+  crosstable_pk: 618
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000110
-  relation: 15
+  relation: 150

--- a/db/ringapp/property/PROP_000111/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000111/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 355
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000111
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 335
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000111
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000112/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000112/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 358
-  example: null
+  example: RING_000002
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000112
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 341
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000112
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000113/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000113/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 356
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000113
@@ -15,7 +15,7 @@ METAPROP_000004:
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000113
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000114/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000114/metaproperties.yaml
@@ -2,20 +2,20 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 285
-  example: null
+  example: RING_000064
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000114
-  relation: 4
+  relation: 163
 METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 348
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000114
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000115/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000115/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 590
+  crosstable_pk: 540
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
@@ -10,9 +10,9 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 544
+  crosstable_pk: 623
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000115
-  relation: 3
+  relation: 153

--- a/db/ringapp/property/PROP_000116/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000116/metaproperties.yaml
@@ -1,21 +1,21 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 610
+  crosstable_pk: 629
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000116
-  relation: 5
+  relation: 164
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 545
+  crosstable_pk: 615
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000116
-  relation: 3
+  relation: 112
 METAPROP_000012:
   citation:
   - 455

--- a/db/ringapp/property/PROP_000117/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000117/metaproperties.yaml
@@ -1,12 +1,12 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 611
+  crosstable_pk: 630
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000117
-  relation: 5
+  relation: 164
 METAPROP_000004:
   citation: []
   commutative_only: false
@@ -15,4 +15,4 @@ METAPROP_000004:
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000117
-  relation: 13
+  relation: 150

--- a/db/ringapp/property/PROP_000118/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000118/metaproperties.yaml
@@ -1,18 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 615
+  crosstable_pk: 632
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000118
-  relation: 6
+  relation: 165
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 540
+  crosstable_pk: 613
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000118
-  relation: 3
+  relation: 109

--- a/db/ringapp/property/PROP_000119/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000119/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 591
+  crosstable_pk: 542
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000120/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000120/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 592
+  crosstable_pk: 543
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000121/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000121/metaproperties.yaml
@@ -1,21 +1,21 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 612
+  crosstable_pk: 631
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000121
-  relation: 5
+  relation: 164
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 624
+  crosstable_pk: 619
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000121
-  relation: 13
+  relation: 150
 METAPROP_000006:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000122/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000122/metaproperties.yaml
@@ -6,16 +6,16 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000122
-  relation: 5
+  relation: 164
 METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 339
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000122
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000123/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000123/metaproperties.yaml
@@ -2,11 +2,11 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 369
-  example: null
+  example: RING_000004
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000123
-  relation: 4
+  relation: 163
 METAPROP_000004:
   citation: []
   commutative_only: false
@@ -15,7 +15,7 @@ METAPROP_000004:
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000123
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000124/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000124/metaproperties.yaml
@@ -6,16 +6,16 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000124
-  relation: 5
+  relation: 164
 METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 345
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000124
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000126/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000126/metaproperties.yaml
@@ -2,20 +2,20 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 370
-  example: null
+  example: RING_000004
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000126
-  relation: 4
+  relation: 163
 METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 342
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000126
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000127/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000127/metaproperties.yaml
@@ -6,16 +6,16 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000127
-  relation: 6
+  relation: 165
 METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 346
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000127
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000129/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000129/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 593
+  crosstable_pk: 530
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000130/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000130/metaproperties.yaml
@@ -6,16 +6,16 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000130
-  relation: 5
+  relation: 164
 METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 338
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000130
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000133/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000133/metaproperties.yaml
@@ -1,12 +1,12 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 605
+  crosstable_pk: 624
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000133
-  relation: 5
+  relation: 164
 METAPROP_000009:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000135/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000135/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 606
+  crosstable_pk: 625
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000135
-  relation: 5
+  relation: 164

--- a/db/ringapp/property/PROP_000136/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000136/metaproperties.yaml
@@ -1,9 +1,9 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 607
+  crosstable_pk: 626
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000136
-  relation: 5
+  relation: 164

--- a/db/ringapp/property/PROP_000137/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000137/metaproperties.yaml
@@ -10,12 +10,12 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 529
+  crosstable_pk: 602
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000137
-  relation: 3
+  relation: 109
 METAPROP_000006:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000138/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000138/metaproperties.yaml
@@ -10,12 +10,12 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 530
+  crosstable_pk: 603
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000138
-  relation: 3
+  relation: 109
 METAPROP_000006:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000140/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000140/metaproperties.yaml
@@ -1,12 +1,12 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 608
+  crosstable_pk: 627
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000140
-  relation: 5
+  relation: 164
 METAPROP_000006:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000142/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000142/metaproperties.yaml
@@ -10,9 +10,9 @@ METAPROP_000003:
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 541
+  crosstable_pk: 614
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000142
-  relation: 3
+  relation: 112

--- a/db/ringapp/property/PROP_000143/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000143/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 594
+  crosstable_pk: 569
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000145/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000145/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 357
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000145
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 349
-  example: null
+  example: RING_000027
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000145
-  relation: 3
+  relation: 153
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000146/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000146/metaproperties.yaml
@@ -1,9 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 595
+  crosstable_pk: 529
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000146
   relation: 1
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 597
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000146
+  relation: 107

--- a/db/ringapp/property/PROP_000147/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000147/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 596
+  crosstable_pk: 570
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000148/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000148/metaproperties.yaml
@@ -1,12 +1,12 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 617
+  crosstable_pk: 571
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000148
-  relation: 7
+  relation: 2
 METAPROP_000004:
   citation:
   - 218

--- a/db/ringapp/property/PROP_000150/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000150/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 597
+  crosstable_pk: 572
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000153/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000153/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 359
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000153
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 343
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000153
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000154/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000154/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 362
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000154
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 350
-  example: null
+  example: RING_000027
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000154
-  relation: 3
+  relation: 153
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000155/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000155/metaproperties.yaml
@@ -25,7 +25,7 @@ METAPROP_000004:
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000155
-  relation: 16
+  relation: null
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000159/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000159/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 598
+  crosstable_pk: 578
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000160/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000160/metaproperties.yaml
@@ -1,18 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 613
+  crosstable_pk: 584
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000160
-  relation: 6
+  relation: 14
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 542
+  crosstable_pk: 620
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000160
-  relation: 3
+  relation: 153

--- a/db/ringapp/property/PROP_000161/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000161/metaproperties.yaml
@@ -1,18 +1,18 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 614
+  crosstable_pk: 585
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000161
-  relation: 6
+  relation: 19
 METAPROP_000004:
   citation: []
   commutative_only: false
-  crosstable_pk: 543
+  crosstable_pk: 621
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000161
-  relation: 3
+  relation: 153

--- a/db/ringapp/property/PROP_000164/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000164/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 599
+  crosstable_pk: 573
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000165/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000165/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 600
+  crosstable_pk: 574
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000166/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000166/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 353
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000166
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 333
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000166
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000167/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000167/metaproperties.yaml
@@ -1,3 +1,12 @@
+METAPROP_000003:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 588
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000003
+  property: PROP_000167
+  relation: 58
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000168/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000168/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 601
+  crosstable_pk: 586
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000169/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000169/metaproperties.yaml
@@ -6,16 +6,16 @@ METAPROP_000003:
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000169
-  relation: 5
+  relation: 61
 METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 344
-  example: null
+  example: RING_000001
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000169
-  relation: 3
+  relation: 109
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000170/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000170/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 602
+  crosstable_pk: 575
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000171/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000171/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 603
+  crosstable_pk: 576
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/property/PROP_000172/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000172/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 363
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000172
@@ -11,11 +11,11 @@ METAPROP_000004:
   citation: []
   commutative_only: false
   crosstable_pk: 351
-  example: null
+  example: RING_000027
   has_metaproperty: false
   metaproperty: METAPROP_000004
   property: PROP_000172
-  relation: 3
+  relation: 153
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000173/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000173/metaproperties.yaml
@@ -2,7 +2,7 @@ METAPROP_000003:
   citation: []
   commutative_only: false
   crosstable_pk: 368
-  example: null
+  example: RING_000101
   has_metaproperty: false
   metaproperty: METAPROP_000003
   property: PROP_000173

--- a/db/ringapp/property/PROP_000175/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000175/metaproperties.yaml
@@ -1,3 +1,21 @@
+METAPROP_000003:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 587
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000003
+  property: PROP_000175
+  relation: 13
+METAPROP_000004:
+  citation: []
+  commutative_only: false
+  crosstable_pk: 594
+  example: null
+  has_metaproperty: false
+  metaproperty: METAPROP_000004
+  property: PROP_000175
+  relation: 106
 METAPROP_000005:
   citation: []
   commutative_only: false

--- a/db/ringapp/property/PROP_000177/metaproperties.yaml
+++ b/db/ringapp/property/PROP_000177/metaproperties.yaml
@@ -1,7 +1,7 @@
 METAPROP_000003:
   citation: []
   commutative_only: false
-  crosstable_pk: 604
+  crosstable_pk: 577
   example: null
   has_metaproperty: false
   metaproperty: METAPROP_000003

--- a/db/ringapp/relation/data.yaml
+++ b/db/ringapp/relation/data.yaml
@@ -4,92 +4,832 @@ RINGRELATION_000001:
   relation_type: SUBRING_OF
   second: RING_000101
 RINGRELATION_000002:
-  first: RING_000053
-  note: ''
-  relation_type: IMAGE_OF
-  second: RING_000001
-RINGRELATION_000003:
-  first: RING_000049
-  note: ''
-  relation_type: IMAGE_OF
-  second: RING_000027
-RINGRELATION_000004:
-  first: RING_000077
-  note: ''
-  relation_type: SUBRING_OF
-  second: RING_000004
-RINGRELATION_000005:
-  first: RING_000036
-  note: ''
-  relation_type: SUBRING_OF
-  second: RING_000007
-RINGRELATION_000006:
-  first: RING_000064
-  note: ''
-  relation_type: SUBRING_OF
-  second: RING_000027
-RINGRELATION_000007:
   first: RING_000001
-  note: ''
+  note: field of fractions
   relation_type: SUBRING_OF
   second: RING_000002
+RINGRELATION_000003:
+  first: RING_000001
+  note: constant terms
+  relation_type: SUBRING_OF
+  second: RING_000006
+RINGRELATION_000004:
+  first: RING_000001
+  note: diagonal inclusion
+  relation_type: SUBRING_OF
+  second: RING_000019
+RINGRELATION_000005:
+  first: RING_000001
+  note: scalars
+  relation_type: SUBRING_OF
+  second: RING_000022
+RINGRELATION_000006:
+  first: RING_000001
+  note: scalars of Dorroh extension. Many elements have additive order 2
+  relation_type: SUBRING_OF
+  second: RING_000026
+RINGRELATION_000007:
+  first: RING_000001
+  note: ideal intersects the base ring trivially
+  relation_type: SUBRING_OF
+  second: RING_000032
 RINGRELATION_000008:
-  first: RING_000002
-  note: ''
+  first: RING_000001
+  note: integers in a number field
   relation_type: SUBRING_OF
-  second: RING_000003
+  second: RING_000033
 RINGRELATION_000009:
-  first: RING_000003
-  note: ''
+  first: RING_000001
+  note: integers in a number field
   relation_type: SUBRING_OF
-  second: RING_000004
+  second: RING_000034
 RINGRELATION_000010:
-  first: RING_000004
-  note: ''
+  first: RING_000001
+  note: by definition
   relation_type: SUBRING_OF
-  second: RING_000005
+  second: RING_000036
 RINGRELATION_000011:
   first: RING_000001
-  note: ''
+  note: scalars of trivial extension
+  relation_type: SUBRING_OF
+  second: RING_000043
+RINGRELATION_000012:
+  first: RING_000001
+  note: base ring of localization
+  relation_type: SUBRING_OF
+  second: RING_000055
+RINGRELATION_000013:
+  first: RING_000001
+  note: scalars of trivial extension
+  relation_type: SUBRING_OF
+  second: RING_000063
+RINGRELATION_000014:
+  first: RING_000001
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000069
+RINGRELATION_000015:
+  first: RING_000001
+  note: torsionless additive group
+  relation_type: SUBRING_OF
+  second: RING_000074
+RINGRELATION_000016:
+  first: RING_000001
+  note: torsionless additive group
+  relation_type: SUBRING_OF
+  second: RING_000075
+RINGRELATION_000017:
+  first: RING_000001
+  note: integers of number field
+  relation_type: SUBRING_OF
+  second: RING_000076
+RINGRELATION_000018:
+  first: RING_000001
+  note: subring of integers of number field
+  relation_type: SUBRING_OF
+  second: RING_000077
+RINGRELATION_000019:
+  first: RING_000001
+  note: torsionless additive group
+  relation_type: SUBRING_OF
+  second: RING_000084
+RINGRELATION_000020:
+  first: RING_000001
+  note: base ring of localization
+  relation_type: SUBRING_OF
+  second: RING_000095
+RINGRELATION_000021:
+  first: RING_000001
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000096
+RINGRELATION_000022:
+  first: RING_000001
+  note: diagonal inclusion
+  relation_type: SUBRING_OF
+  second: RING_000097
+RINGRELATION_000023:
+  first: RING_000001
+  note: torsionless additive group
+  relation_type: SUBRING_OF
+  second: RING_000105
+RINGRELATION_000024:
+  first: RING_000001
+  note: scalars of trivial extension
+  relation_type: SUBRING_OF
+  second: RING_000122
+RINGRELATION_000025:
+  first: RING_000001
+  note: diagonal inclusion
+  relation_type: SUBRING_OF
+  second: RING_000126
+RINGRELATION_000026:
+  first: RING_000001
+  note: torsionless additive group
+  relation_type: SUBRING_OF
+  second: RING_000150
+RINGRELATION_000027:
+  first: RING_000001
+  note: scalars of skew power series
+  relation_type: SUBRING_OF
+  second: RING_000153
+RINGRELATION_000028:
+  first: RING_000001
+  note: diagonal inclusion
+  relation_type: SUBRING_OF
+  second: RING_000154
+RINGRELATION_000029:
+  first: RING_000001
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000160
+RINGRELATION_000030:
+  first: RING_000002
+  note: constant terms
+  relation_type: SUBRING_OF
+  second: RING_000007
+RINGRELATION_000031:
+  first: RING_000002
+  note: prime field
+  relation_type: SUBRING_OF
+  second: RING_000017
+RINGRELATION_000032:
+  first: RING_000002
+  note: prime field
+  relation_type: SUBRING_OF
+  second: RING_000018
+RINGRELATION_000033:
+  first: RING_000002
+  note: diagonal inclusion
+  relation_type: SUBRING_OF
+  second: RING_000020
+RINGRELATION_000034:
+  first: RING_000002
+  note: $\mathbb Q$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000059
+RINGRELATION_000035:
+  first: RING_000002
+  note: prime field
+  relation_type: SUBRING_OF
+  second: RING_000085
+RINGRELATION_000036:
+  first: RING_000002
+  note: base ring of localization
+  relation_type: SUBRING_OF
+  second: RING_000100
+RINGRELATION_000037:
+  first: RING_000002
+  note: prime field
+  relation_type: SUBRING_OF
+  second: RING_000101
+RINGRELATION_000038:
+  first: RING_000002
+  note: base ring of localization
+  relation_type: SUBRING_OF
+  second: RING_000131
+RINGRELATION_000039:
+  first: RING_000002
+  note: prime field
+  relation_type: SUBRING_OF
+  second: RING_000140
+RINGRELATION_000040:
+  first: RING_000002
+  note: prime field
+  relation_type: SUBRING_OF
+  second: RING_000156
+RINGRELATION_000041:
+  first: RING_000002
+  note: $\mathbb Q$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000158
+RINGRELATION_000042:
+  first: RING_000002
+  note: $\mathbb Q$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000159
+RINGRELATION_000043:
+  first: RING_000003
+  note: degree 2 extension
   relation_type: SUBRING_OF
   second: RING_000004
-RINGRELATION_000012:
-  first: RING_000044
-  note: ''
+RINGRELATION_000044:
+  first: RING_000003
+  note: ideal intersects the base ring trivially
   relation_type: SUBRING_OF
-  second: RING_000015
-RINGRELATION_000013:
-  first: RING_000090
-  note: ''
+  second: RING_000049
+RINGRELATION_000045:
+  first: RING_000003
+  note: ideal intersects the base ring trivially
+  relation_type: SUBRING_OF
+  second: RING_000050
+RINGRELATION_000046:
+  first: RING_000003
+  note: ring of real functions
+  relation_type: SUBRING_OF
+  second: RING_000068
+RINGRELATION_000047:
+  first: RING_000003
+  note: polynomial ring
+  relation_type: SUBRING_OF
+  second: RING_000088
+RINGRELATION_000048:
+  first: RING_000003
+  note: ideal intersects the base ring trivially
+  relation_type: SUBRING_OF
+  second: RING_000091
+RINGRELATION_000049:
+  first: RING_000003
+  note: base ring of completion
+  relation_type: SUBRING_OF
+  second: RING_000092
+RINGRELATION_000050:
+  first: RING_000003
+  note: the standard part map
+  relation_type: SUBRING_OF
+  second: RING_000107
+RINGRELATION_000051:
+  first: RING_000003
+  note: ring of real functions
+  relation_type: SUBRING_OF
+  second: RING_000130
+RINGRELATION_000052:
+  first: RING_000003
+  note: ring of real functions
+  relation_type: SUBRING_OF
+  second: RING_000155
+RINGRELATION_000053:
+  first: RING_000004
+  note: maximal commutative subalgebra
+  relation_type: SUBRING_OF
+  second: RING_000005
+RINGRELATION_000054:
+  first: RING_000004
+  note: ring of complex functions
+  relation_type: SUBRING_OF
+  second: RING_000037
+RINGRELATION_000055:
+  first: RING_000004
+  note: diagonal inclusion
+  relation_type: SUBRING_OF
+  second: RING_000087
+RINGRELATION_000056:
+  first: RING_000004
+  note: $\mathbb C$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000136
+RINGRELATION_000057:
+  first: RING_000004
+  note: $\mathbb C$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000144
+RINGRELATION_000058:
+  first: RING_000004
+  note: $\mathbb C$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000145
+RINGRELATION_000059:
+  first: RING_000004
+  note: $\mathbb C$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000147
+RINGRELATION_000060:
+  first: RING_000005
+  note: diagonal inclusion
+  relation_type: SUBRING_OF
+  second: RING_000152
+RINGRELATION_000061:
+  first: RING_000006
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000007
+RINGRELATION_000062:
+  first: RING_000006
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000022
+RINGRELATION_000063:
+  first: RING_000006
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000036
+RINGRELATION_000064:
+  first: RING_000006
+  note: there are transcendental $p$-adic integers
+  relation_type: SUBRING_OF
+  second: RING_000084
+RINGRELATION_000065:
+  first: RING_000006
+  note: there are transcendental $p$-adic integers
+  relation_type: SUBRING_OF
+  second: RING_000105
+RINGRELATION_000066:
+  first: RING_000006
+  note: there are transcendental $p$-adic integers
+  relation_type: SUBRING_OF
+  second: RING_000122
+RINGRELATION_000067:
+  first: RING_000006
+  note: there are transcendental $p$-adic integers
+  relation_type: SUBRING_OF
+  second: RING_000150
+RINGRELATION_000068:
+  first: RING_000007
+  note: there are transcendental reals
+  relation_type: SUBRING_OF
+  second: RING_000003
+RINGRELATION_000069:
+  first: RING_000007
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000061
+RINGRELATION_000070:
+  first: RING_000007
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000100
+RINGRELATION_000071:
+  first: RING_000007
+  note: componentwise inclusion
+  relation_type: SUBRING_OF
+  second: RING_000104
+RINGRELATION_000072:
+  first: RING_000007
+  note: $\mathbb Q[b]$
+  relation_type: SUBRING_OF
+  second: RING_000112
+RINGRELATION_000073:
+  first: RING_000007
+  note: take any nonzero group element
+  relation_type: SUBRING_OF
+  second: RING_000117
+RINGRELATION_000074:
+  first: RING_000007
+  note: $\mathbb Q[y]$
+  relation_type: SUBRING_OF
+  second: RING_000120
+RINGRELATION_000075:
+  first: RING_000007
+  note: $\mathbb Q[x_1^2]$
+  relation_type: SUBRING_OF
+  second: RING_000131
+RINGRELATION_000076:
+  first: RING_000007
+  note: $\mathbb Q[x_0]$
+  relation_type: SUBRING_OF
+  second: RING_000148
+RINGRELATION_000077:
+  first: RING_000007
+  note: there are transcendental $p$-adic numbers
+  relation_type: SUBRING_OF
+  second: RING_000151
+RINGRELATION_000078:
+  first: RING_000007
+  note: $\mathbb Q[x_0]$
+  relation_type: SUBRING_OF
+  second: RING_000158
+RINGRELATION_000079:
+  first: RING_000018
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000123
+RINGRELATION_000080:
+  first: RING_000101
+  note: there are transcendental $p$-adic integers
+  relation_type: SUBRING_OF
+  second: RING_000085
+RINGRELATION_000081:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000016
+RINGRELATION_000082:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000023
+RINGRELATION_000083:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000024
+RINGRELATION_000084:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000025
+RINGRELATION_000085:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000039
+RINGRELATION_000086:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000041
+RINGRELATION_000087:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000052
+RINGRELATION_000088:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000057
+RINGRELATION_000089:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000067
+RINGRELATION_000090:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000071
+RINGRELATION_000091:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000072
+RINGRELATION_000092:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000106
+RINGRELATION_000093:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000109
+RINGRELATION_000094:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000113
+RINGRELATION_000095:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000114
+RINGRELATION_000096:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000121
+RINGRELATION_000097:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000124
+RINGRELATION_000098:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000132
+RINGRELATION_000099:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000134
+RINGRELATION_000100:
+  first: RING_000102
+  note: $F_2$-algebra
+  relation_type: SUBRING_OF
+  second: RING_000157
+RINGRELATION_000101:
+  first: RING_000001
+  note: $(x)$
   relation_type: IMAGE_OF
-  second: RING_000098
-RINGRELATION_000014:
-  first: RING_000014
-  note: ''
-  relation_type: SUBRING_OF
-  second: RING_000012
-RINGRELATION_000015:
-  first: RING_000164
-  note: ''
+  second: RING_000036
+RINGRELATION_000102:
+  first: RING_000001
+  note: $(x)$
+  relation_type: IMAGE_OF
+  second: RING_000006
+RINGRELATION_000103:
+  first: RING_000001
+  note: $(x+1 )$
+  relation_type: IMAGE_OF
+  second: RING_000032
+RINGRELATION_000104:
+  first: RING_000001
+  note: $(x,y)$
+  relation_type: IMAGE_OF
+  second: RING_000022
+RINGRELATION_000105:
+  first: RING_000001
+  note: trivial extension
+  relation_type: IMAGE_OF
+  second: RING_000043
+RINGRELATION_000106:
+  first: RING_000001
+  note: trivial extension
+  relation_type: IMAGE_OF
+  second: RING_000063
+RINGRELATION_000107:
+  first: RING_000001
+  note: $V$ is an ideal
+  relation_type: IMAGE_OF
+  second: RING_000096
+RINGRELATION_000108:
+  first: RING_000102
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000001
+RINGRELATION_000109:
+  first: RING_000053
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000001
+RINGRELATION_000110:
+  first: RING_000009
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000001
+RINGRELATION_000111:
+  first: RING_000008
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000001
+RINGRELATION_000112:
+  first: RING_000010
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000001
+RINGRELATION_000113:
+  first: RING_000032
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000006
+RINGRELATION_000114:
+  first: RING_000034
+  note: ideal generated by minimal polynomial
+  relation_type: IMAGE_OF
+  second: RING_000006
+RINGRELATION_000115:
+  first: RING_000077
+  note: ideal generated by minimal polynomial
+  relation_type: IMAGE_OF
+  second: RING_000006
+RINGRELATION_000116:
+  first: RING_000076
+  note: ideal generated by minimal polynomial
+  relation_type: IMAGE_OF
+  second: RING_000006
+RINGRELATION_000117:
+  first: RING_000102
+  note: augmentation
+  relation_type: IMAGE_OF
+  second: RING_000157
+RINGRELATION_000118:
+  first: RING_000102
+  note: augmentation
+  relation_type: IMAGE_OF
+  second: RING_000025
+RINGRELATION_000119:
+  first: RING_000102
+  note: $(x,y)$
+  relation_type: IMAGE_OF
+  second: RING_000023
+RINGRELATION_000120:
+  first: RING_000102
+  note: direct factor
+  relation_type: IMAGE_OF
+  second: RING_000057
+RINGRELATION_000121:
+  first: RING_000102
+  note: 2-adics by maximal ideal
+  relation_type: IMAGE_OF
+  second: RING_000150
+RINGRELATION_000122:
+  first: RING_000102
+  note: the second column
+  relation_type: IMAGE_OF
+  second: RING_000016
+RINGRELATION_000123:
+  first: RING_000102
+  note: $(x,y,z)$
+  relation_type: IMAGE_OF
+  second: RING_000024
+RINGRELATION_000124:
+  first: RING_000102
+  note: $(2)$
+  relation_type: IMAGE_OF
+  second: RING_000029
+RINGRELATION_000125:
+  first: RING_000102
+  note: the first row is an ideal
+  relation_type: IMAGE_OF
+  second: RING_000030
+RINGRELATION_000126:
+  first: RING_000102
+  note: $(2)$ is inert, see MO 137449
+  relation_type: IMAGE_OF
+  second: RING_000034
+RINGRELATION_000127:
+  first: RING_000102
+  note: $(2)$ is ramified (see MO 137449), and $R/(2,1-\sqrt{-5}) \cong Z/(2)$.
+  relation_type: IMAGE_OF
+  second: RING_000077
+RINGRELATION_000128:
+  first: RING_000057
+  note: first row
+  relation_type: IMAGE_OF
+  second: RING_000039
+RINGRELATION_000129:
+  first: RING_000102
+  note: three upper rows
+  relation_type: IMAGE_OF
+  second: RING_000041
+RINGRELATION_000130:
+  first: RING_000102
+  note: right column
+  relation_type: IMAGE_OF
+  second: RING_000046
+RINGRELATION_000131:
+  first: RING_000102
+  note: augmentation
+  relation_type: IMAGE_OF
+  second: RING_000051
+RINGRELATION_000132:
+  first: RING_000102
+  note: the subrng
+  relation_type: IMAGE_OF
+  second: RING_000052
+RINGRELATION_000133:
+  first: RING_000102
+  note: $R/J(R) \cong F_2 \times M_2(F_2)$
+  relation_type: IMAGE_OF
+  second: RING_000072
+RINGRELATION_000134:
+  first: RING_000102
+  note: set all letters to zero
+  relation_type: IMAGE_OF
+  second: RING_000113
+RINGRELATION_000135:
+  first: RING_000102
+  note: set letters to 0
+  relation_type: IMAGE_OF
+  second: RING_000134
+RINGRELATION_000136:
+  first: RING_000102
+  note: $R \cong S[x]/(x^2)$; take $(2, x)$
   relation_type: IMAGE_OF
   second: RING_000139
-RINGRELATION_000016:
-  first: RING_000119
-  note: ''
+RINGRELATION_000137:
+  first: RING_000002
+  note: $(x)$
   relation_type: IMAGE_OF
-  second: RING_000165
-RINGRELATION_000017:
-  first: RING_000079
-  note: ''
+  second: RING_000007
+RINGRELATION_000138:
+  first: RING_000002
+  note: first row
   relation_type: IMAGE_OF
-  second: RING_000166
-RINGRELATION_000018:
-  first: RING_000082
-  note: ''
+  second: RING_000019
+RINGRELATION_000139:
+  first: RING_000002
+  note: second column
+  relation_type: IMAGE_OF
+  second: RING_000020
+RINGRELATION_000140:
+  first: RING_000002
+  note: make letters zero
+  relation_type: IMAGE_OF
+  second: RING_000059
+RINGRELATION_000141:
+  first: RING_000002
+  note: maximal ideal
+  relation_type: IMAGE_OF
+  second: RING_000104
+RINGRELATION_000142:
+  first: RING_000102
+  note: outsize $\Bbb Z_2$ + $(2)$ inside
+  relation_type: IMAGE_OF
+  second: RING_000105
+RINGRELATION_000143:
+  first: RING_000002
+  note: augmentation
+  relation_type: IMAGE_OF
+  second: RING_000117
+RINGRELATION_000144:
+  first: RING_000002
+  note: make letters zero
+  relation_type: IMAGE_OF
+  second: RING_000120
+RINGRELATION_000145:
+  first: RING_000102
+  note: $2B+Q/B$
+  relation_type: IMAGE_OF
+  second: RING_000122
+RINGRELATION_000146:
+  first: RING_000102
+  note: augmentation
+  relation_type: IMAGE_OF
+  second: RING_000124
+RINGRELATION_000147:
+  first: RING_000002
+  note: make letters zero
+  relation_type: IMAGE_OF
+  second: RING_000148
+RINGRELATION_000148:
+  first: RING_000002
+  note: make letters zero
+  relation_type: IMAGE_OF
+  second: RING_000158
+RINGRELATION_000149:
+  first: RING_000002
+  note: make letters zero
+  relation_type: IMAGE_OF
+  second: RING_000159
+RINGRELATION_000150:
+  first: RING_000116
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000098
+RINGRELATION_000151:
+  first: RING_000090
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000098
+RINGRELATION_000152:
+  first: RING_000089
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000098
+RINGRELATION_000153:
+  first: RING_000149
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000027
+RINGRELATION_000154:
+  first: RING_000003
+  note: make letters zero
+  relation_type: IMAGE_OF
+  second: RING_000050
+RINGRELATION_000155:
+  first: RING_000050
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000088
+RINGRELATION_000156:
+  first: RING_000003
+  note: $(x)$
+  relation_type: IMAGE_OF
+  second: RING_000049
+RINGRELATION_000157:
+  first: RING_000049
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000088
+RINGRELATION_000158:
+  first: RING_000091
+  note: by definition
+  relation_type: IMAGE_OF
+  second: RING_000088
+RINGRELATION_000159:
+  first: RING_000049
+  note: $(x-y,y-z)$
+  relation_type: IMAGE_OF
+  second: RING_000050
+RINGRELATION_000160:
+  first: RING_000008
+  note: $(p)$
+  relation_type: IMAGE_OF
+  second: RING_000010
+RINGRELATION_000161:
+  first: RING_000081
+  note: see Expanded details
   relation_type: SUBRING_OF
-  second: RING_000081
-RINGRELATION_000019:
-  first: RING_000168
-  note: ''
-  relation_type: IMAGE_OF
-  second: RING_000167
+  second: RING_000080
+RINGRELATION_000162:
+  first: RING_000082
+  note: see Expanded details
+  relation_type: SUBRING_OF
+  second: RING_000080
+RINGRELATION_000163:
+  first: RING_000077
+  note: algebraic closure
+  relation_type: SUBRING_OF
+  second: RING_000004
+RINGRELATION_000164:
+  first: RING_000036
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000007
+RINGRELATION_000165:
+  first: RING_000064
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000027
+RINGRELATION_000166:
+  first: RING_000044
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000015
+RINGRELATION_000167:
+  first: RING_000014
+  note: by definition
+  relation_type: SUBRING_OF
+  second: RING_000012


### PR DESCRIPTION
How the files from this PR were obtained:
1) added 161 "my own" + 5 "your" relations through admin interface
2) pulled dart_data/master
3) from `python manage.py shell --settings=...`, using slightly modified `propagate_relation` (that can overwrite existing `relation` fields in PropertyMetaproperties), reordered them (I had it mixed because originally the metaproperties were not connected with relation types)
4) ran db_to_data export
5) via GUI, discarded changes that were made on step 4) to the following files: `moduleapp/relation/data.yaml` (you added a module relation), `METAPROP_00000?.yaml` (your descriptions are preferred), `RING_000???/data.yaml` (description updates).

So, to check correctness of this PR you can import to a local copy and inspect the list visually through admin interface. 

---
I didn't notice the ring description changes before doing the above steps, so currently this PR misses " $\Bbb R[x]/(x^2)$ is a quotient of $\Bbb R[[x^2,x^3]]$". Other relations are either duplicate to my ones (x7), related to newly-added rings (x5), or successfully added (x5). I'll reimport dart_data to my local copy and commit again.